### PR TITLE
Error occurs when converting data to mysql format

### DIFF
--- a/DataConverter.py
+++ b/DataConverter.py
@@ -513,7 +513,7 @@ class DataConverterCommand(sublime_plugin.TextCommand):
 
         for row in data:
             values += self.indent + "("
-            values += self.type_loop(row, form='{1},', nulltxt='NULL')
+            values += self.type_loop(row, formt='{1},', nulltxt='NULL')
 
             values = values[:-1] + '),' + self.newline
 


### PR DESCRIPTION
Key parameter of definition "type_loop" was changed from "form" to "formt" before, so I changed this line.
